### PR TITLE
Allow mail from servers without matching reverse PTR

### DIFF
--- a/modules/services/email/nixcloud-email.nix
+++ b/modules/services/email/nixcloud-email.nix
@@ -352,7 +352,7 @@ in {
           smtpd_client_restrictions = [
             "permit_mynetworks"
             "permit_sasl_authenticated"
-            "reject_unknown_client_hostname" # reject reverse PTR not matching hostname
+            "reject_unknown_reverse_client_hostname" # reject when no reverse PTR
           ];
           smtpd_helo_required = "yes";
           smtpd_helo_restrictions = [


### PR DESCRIPTION
Some mail servers (like mine) don't have a reverse PTR matching the hostname of the mail server (in my case because it is really expensive). And while most mailservers accept mails from servers like mine (I have never had problems with it until I tried mailing @qknight two weeks ago) NixCloud will reject my mails.

I have replaced the `reject_unknown_client_hostname ` restriction with the less restrictive `reject_unknown_reverse_client_hostname` which only rejects mail servers that have no reverse PTR