### PR TITLE
documentation: use HTTPS in example for static webservers.

### DIFF
--- a/documentation/nixcloud.webservices.md
+++ b/documentation/nixcloud.webservices.md
@@ -137,8 +137,8 @@ Using `darkhttpd` backend:
       root = /www;
       proxyOptions = {
         port = 3032;
-        http.mode = "on";
-        https.mode = "off";
+        http.mode = "redirect_to_https";
+        https.mode = "on";
         domain = "example.com";
       };
     };
@@ -155,8 +155,8 @@ Using `nginx` backend:
       root = /www;
       proxyOptions = {
         port = 3032;
-        http.mode = "on";
-        https.mode = "off";
+        http.mode = "redirect_to_https";
+        https.mode = "on";
         domain = "example.com";
       };
     };


### PR DESCRIPTION
Finally a PR after all this nitpicking ;)

I'd suggest to show a working HTTPS config in the docs, as it would make things easier to users who want to use HTTPS. Users who want to stick with HTTP would still have a good time deriving there config from the example.

My user story behind this PR:

I used `nixcloud.webservices.static-darkhttpd."erictapen.de"` with 

```
http.mode = "off";
https.mode = "on";
```

and realised after a while, that this results in an `nginx` error if I try to open `http://erictapen.de`. Switching both modes to `on` helped, but made my site accessible via HTTP, which is not what I wanted. After taking some time, I had a look at the source and discovered `http.mode = "redirect_to_https";`, which solved my issue.