### PR TITLE
Change incorrect Mediawiki reference

### DIFF
--- a/modules/web/services/filesender/default.nix
+++ b/modules/web/services/filesender/default.nix
@@ -20,7 +20,7 @@ with lib;
     };
     dbName = mkOption {
       default = "filesender";
-      description = "Name of the database that holds the MediaWiki data.";
+      description = "Name of the database that holds the FileSender data.";
     };
     dbServer = mkOption {
       default = "localhost"; # "" for using a Unix domain socket


### PR DESCRIPTION
This was incorrectly copied over from another service used as a template.
Otherwise people might get confused.

Note that this is still an old FileSender version, a much improved 2.1 version has been released a while ago:

https://github.com/filesender/filesender