### PR TITLE
email: Added per-user spam checking and training

### DIFF
--- a/modules/core/packages.nix
+++ b/modules/core/packages.nix
@@ -11,6 +11,13 @@ with pkgs;
       #  src = /etc/nixos/pkgs/lxc;
       #  patches = [  ];
       #});
+      rspamd = let
+          version = super.rspamd.version;
+        in if (lib.versionAtLeast version "1.7.3") && (lib.versionOlder version "1.8.1")
+          then super.rspamd.overrideAttrs (oldAttrs: rec {
+            patches = ["${./rspamd}/rspamd-${version}-local-rules.patch"];
+          })
+          else super.rspamd;
     })
   ];
 }

--- a/modules/core/rspamd/rspamd-1.7.3-local-rules.patch
+++ b/modules/core/rspamd/rspamd-1.7.3-local-rules.patch
@@ -1,0 +1,72 @@
+diff --git a/rules/rspamd.lua b/rules/rspamd.lua
+index 6b53828ee..0f7990d58 100644
+--- a/rules/rspamd.lua
++++ b/rules/rspamd.lua
+@@ -21,7 +21,7 @@ require "global_functions" ()
+ config['regexp'] = {}
+ rspamd_maps = {} -- Global maps
+ 
+-local local_conf = rspamd_paths['CONFDIR']
++local local_conf = rspamd_paths['LOCAL_CONFDIR']
+ local local_rules = rspamd_paths['RULESDIR']
+ 
+ dofile(local_rules .. '/regexp/headers.lua')
+@@ -74,4 +74,4 @@ if rmaps and type(rmaps) == 'table' then
+ end
+ 
+ local rspamd_nn = require "lua_nn"
+-rspamd_nn.load_rspamd_nn() -- Load defined models
+\ No newline at end of file
++rspamd_nn.load_rspamd_nn() -- Load defined models
+diff --git a/src/libserver/cfg_rcl.c b/src/libserver/cfg_rcl.c
+index 6019d7c7d..0e17afa29 100644
+--- a/src/libserver/cfg_rcl.c
++++ b/src/libserver/cfg_rcl.c
+@@ -612,6 +612,7 @@ rspamd_rcl_worker_handler (rspamd_mempool_t *pool, const ucl_object_t *obj,
+ }
+ 
+ #define RSPAMD_CONFDIR_INDEX "CONFDIR"
++#define RSPAMD_LOCAL_CONFDIR_INDEX "LOCAL_CONFDIR"
+ #define RSPAMD_RUNDIR_INDEX "RUNDIR"
+ #define RSPAMD_DBDIR_INDEX "DBDIR"
+ #define RSPAMD_LOGDIR_INDEX "LOGDIR"
+@@ -819,6 +820,7 @@ rspamd_rcl_set_lua_globals (struct rspamd_config *cfg, lua_State *L,
+ 	lua_getglobal (L, "rspamd_paths");
+ 	if (lua_isnil (L, -1)) {
+ 		const gchar *confdir = RSPAMD_CONFDIR, *rundir = RSPAMD_RUNDIR,
++				*local_confdir = RSPAMD_LOCAL_CONFDIR,
+ 				*dbdir = RSPAMD_DBDIR, *logdir = RSPAMD_LOGDIR,
+ 				*wwwdir = RSPAMD_WWWDIR, *pluginsdir = RSPAMD_PLUGINSDIR,
+ 				*rulesdir = RSPAMD_RULESDIR, *lualibdir = RSPAMD_LUALIBDIR,
+@@ -866,6 +868,11 @@ rspamd_rcl_set_lua_globals (struct rspamd_config *cfg, lua_State *L,
+ 			confdir = t;
+ 		}
+ 
++		t = getenv ("LOCAL_CONFDIR");
++		if (t) {
++			local_confdir = t;
++		}
++
+ 
+ 		if (vars) {
+ 			t = g_hash_table_lookup (vars, "PLUGINSDIR");
+@@ -898,6 +905,11 @@ rspamd_rcl_set_lua_globals (struct rspamd_config *cfg, lua_State *L,
+ 				confdir = t;
+ 			}
+ 
++			t = g_hash_table_lookup (vars, "LOCAL_CONFDIR");
++			if (t) {
++				local_confdir = t;
++			}
++
+ 			t = g_hash_table_lookup (vars, "DBDIR");
+ 			if (t) {
+ 				dbdir = t;
+@@ -912,6 +924,7 @@ rspamd_rcl_set_lua_globals (struct rspamd_config *cfg, lua_State *L,
+ 		lua_createtable (L, 0, 9);
+ 
+ 		rspamd_lua_table_set (L, RSPAMD_CONFDIR_INDEX, confdir);
++		rspamd_lua_table_set (L, RSPAMD_LOCAL_CONFDIR_INDEX, local_confdir);
+ 		rspamd_lua_table_set (L, RSPAMD_RUNDIR_INDEX, rundir);
+ 		rspamd_lua_table_set (L, RSPAMD_DBDIR_INDEX, dbdir);
+ 		rspamd_lua_table_set (L, RSPAMD_LOGDIR_INDEX, logdir);

--- a/modules/core/rspamd/rspamd-1.7.9-local-rules.patch
+++ b/modules/core/rspamd/rspamd-1.7.9-local-rules.patch
@@ -1,0 +1,81 @@
+diff --git a/rules/rspamd.lua b/rules/rspamd.lua
+index a193eb495..40b6af704 100644
+--- a/rules/rspamd.lua
++++ b/rules/rspamd.lua
+@@ -21,7 +21,7 @@ require "global_functions" ()
+ config['regexp'] = {}
+ rspamd_maps = {} -- Global maps
+
+-local local_conf = rspamd_paths['CONFDIR']
++local local_conf = rspamd_paths['LOCAL_CONFDIR']
+ local local_rules = rspamd_paths['RULESDIR']
+ local rspamd_util = require "rspamd_util"
+
+diff --git a/src/lua/lua_common.c b/src/lua/lua_common.c
+index 323957086..1e4538b1c 100644
+--- a/src/lua/lua_common.c
++++ b/src/lua/lua_common.c
+@@ -576,6 +576,7 @@ rspamd_lua_set_globals (struct rspamd_config *cfg, lua_State *L,
+ 	lua_getglobal (L, "rspamd_paths");
+ 	if (lua_isnil (L, -1)) {
+ 		const gchar *confdir = RSPAMD_CONFDIR, *rundir = RSPAMD_RUNDIR,
++				*local_confdir = RSPAMD_LOCAL_CONFDIR,
+ 				*dbdir = RSPAMD_DBDIR, *logdir = RSPAMD_LOGDIR,
+ 				*wwwdir = RSPAMD_WWWDIR, *pluginsdir = RSPAMD_PLUGINSDIR,
+ 				*rulesdir = RSPAMD_RULESDIR, *lualibdir = RSPAMD_LUALIBDIR,
+@@ -623,6 +624,11 @@ rspamd_lua_set_globals (struct rspamd_config *cfg, lua_State *L,
+ 			confdir = t;
+ 		}
+
++		t = getenv ("LOCAL_CONFDIR");
++		if (t) {
++			local_confdir = t;
++		}
++
+
+ 		if (vars) {
+ 			t = g_hash_table_lookup (vars, "PLUGINSDIR");
+@@ -655,6 +661,11 @@ rspamd_lua_set_globals (struct rspamd_config *cfg, lua_State *L,
+ 				confdir = t;
+ 			}
+
++			t = g_hash_table_lookup (vars, "LOCAL_CONFDIR");
++			if (t) {
++				local_confdir = t;
++			}
++
+ 			t = g_hash_table_lookup (vars, "DBDIR");
+ 			if (t) {
+ 				dbdir = t;
+@@ -669,6 +680,7 @@ rspamd_lua_set_globals (struct rspamd_config *cfg, lua_State *L,
+ 		lua_createtable (L, 0, 9);
+
+ 		rspamd_lua_table_set (L, RSPAMD_CONFDIR_INDEX, confdir);
++		rspamd_lua_table_set (L, RSPAMD_LOCAL_CONFDIR_INDEX, local_confdir);
+ 		rspamd_lua_table_set (L, RSPAMD_RUNDIR_INDEX, rundir);
+ 		rspamd_lua_table_set (L, RSPAMD_DBDIR_INDEX, dbdir);
+ 		rspamd_lua_table_set (L, RSPAMD_LOGDIR_INDEX, logdir);
+diff --git a/src/lua/lua_common.h b/src/lua/lua_common.h
+index 838e0fe7a..5810184b7 100644
+--- a/src/lua/lua_common.h
++++ b/src/lua/lua_common.h
+@@ -410,6 +410,7 @@ gboolean rspamd_lua_require_function (lua_State *L, const gchar *modname,
+
+ /* Paths defs */
+ #define RSPAMD_CONFDIR_INDEX "CONFDIR"
++#define RSPAMD_LOCAL_CONFDIR_INDEX "LOCAL_CONFDIR"
+ #define RSPAMD_RUNDIR_INDEX "RUNDIR"
+ #define RSPAMD_DBDIR_INDEX "DBDIR"
+ #define RSPAMD_LOGDIR_INDEX "LOGDIR"
+diff --git a/src/lua/lua_config.c b/src/lua/lua_config.c
+index 2093cbe01..d5d80914b 100644
+--- a/src/lua/lua_config.c
++++ b/src/lua/lua_config.c
+@@ -3339,6 +3339,7 @@ lua_config_load_ucl (lua_State *L)
+
+ 		if (lua_istable (L, -1)) {
+ 			LUA_TABLE_TO_HASH(paths, RSPAMD_CONFDIR_INDEX);
++			LUA_TABLE_TO_HASH(paths, RSPAMD_LOCAL_CONFDIR_INDEX);
+ 			LUA_TABLE_TO_HASH(paths, RSPAMD_RUNDIR_INDEX);
+ 			LUA_TABLE_TO_HASH(paths, RSPAMD_DBDIR_INDEX);
+ 			LUA_TABLE_TO_HASH(paths, RSPAMD_LOGDIR_INDEX);

--- a/modules/core/rspamd/rspamd-1.8.0-local-rules.patch
+++ b/modules/core/rspamd/rspamd-1.8.0-local-rules.patch
@@ -1,0 +1,81 @@
+diff --git a/rules/rspamd.lua b/rules/rspamd.lua
+index a193eb495..67136cc6e 100644
+--- a/rules/rspamd.lua
++++ b/rules/rspamd.lua
+@@ -21,7 +21,7 @@ require "global_functions" ()
+ config['regexp'] = {}
+ rspamd_maps = {} -- Global maps
+ 
+-local local_conf = rspamd_paths['CONFDIR']
++local local_conf = rspamd_paths['LOCAL_CONFDIR']
+ local local_rules = rspamd_paths['RULESDIR']
+ local rspamd_util = require "rspamd_util"
+ 
+diff --git a/src/lua/lua_common.c b/src/lua/lua_common.c
+index ac7a393b8..233397fc0 100644
+--- a/src/lua/lua_common.c
++++ b/src/lua/lua_common.c
+@@ -581,6 +581,7 @@ rspamd_lua_set_globals (struct rspamd_config *cfg, lua_State *L,
+ 	lua_getglobal (L, "rspamd_paths");
+ 	if (lua_isnil (L, -1)) {
+ 		const gchar *confdir = RSPAMD_CONFDIR, *rundir = RSPAMD_RUNDIR,
++				*local_confdir = RSPAMD_LOCAL_CONFDIR,
+ 				*dbdir = RSPAMD_DBDIR, *logdir = RSPAMD_LOGDIR,
+ 				*wwwdir = RSPAMD_WWWDIR, *pluginsdir = RSPAMD_PLUGINSDIR,
+ 				*rulesdir = RSPAMD_RULESDIR, *lualibdir = RSPAMD_LUALIBDIR,
+@@ -628,6 +629,11 @@ rspamd_lua_set_globals (struct rspamd_config *cfg, lua_State *L,
+ 			confdir = t;
+ 		}
+ 
++		t = getenv ("LOCAL_CONFDIR");
++		if (t) {
++			local_confdir = t;
++		}
++
+ 
+ 		if (vars) {
+ 			t = g_hash_table_lookup (vars, "PLUGINSDIR");
+@@ -660,6 +666,11 @@ rspamd_lua_set_globals (struct rspamd_config *cfg, lua_State *L,
+ 				confdir = t;
+ 			}
+ 
++			t = g_hash_table_lookup (vars, "LOCAL_CONFDIR");
++			if (t) {
++				local_confdir = t;
++			}
++
+ 			t = g_hash_table_lookup (vars, "DBDIR");
+ 			if (t) {
+ 				dbdir = t;
+@@ -674,6 +685,7 @@ rspamd_lua_set_globals (struct rspamd_config *cfg, lua_State *L,
+ 		lua_createtable (L, 0, 9);
+ 
+ 		rspamd_lua_table_set (L, RSPAMD_CONFDIR_INDEX, confdir);
++		rspamd_lua_table_set (L, RSPAMD_LOCAL_CONFDIR_INDEX, local_confdir);
+ 		rspamd_lua_table_set (L, RSPAMD_RUNDIR_INDEX, rundir);
+ 		rspamd_lua_table_set (L, RSPAMD_DBDIR_INDEX, dbdir);
+ 		rspamd_lua_table_set (L, RSPAMD_LOGDIR_INDEX, logdir);
+diff --git a/src/lua/lua_common.h b/src/lua/lua_common.h
+index af0b5f824..fccbf5115 100644
+--- a/src/lua/lua_common.h
++++ b/src/lua/lua_common.h
+@@ -425,6 +425,7 @@ gboolean rspamd_lua_require_function (lua_State *L, const gchar *modname,
+ 
+ /* Paths defs */
+ #define RSPAMD_CONFDIR_INDEX "CONFDIR"
++#define RSPAMD_LOCAL_CONFDIR_INDEX "LOCAL_CONFDIR"
+ #define RSPAMD_RUNDIR_INDEX "RUNDIR"
+ #define RSPAMD_DBDIR_INDEX "DBDIR"
+ #define RSPAMD_LOGDIR_INDEX "LOGDIR"
+diff --git a/src/lua/lua_config.c b/src/lua/lua_config.c
+index d72c5ff66..b609348fe 100644
+--- a/src/lua/lua_config.c
++++ b/src/lua/lua_config.c
+@@ -3441,6 +3441,7 @@ lua_config_load_ucl (lua_State *L)
+ 
+ 		if (lua_istable (L, -1)) {
+ 			LUA_TABLE_TO_HASH(paths, RSPAMD_CONFDIR_INDEX);
++			LUA_TABLE_TO_HASH(paths, RSPAMD_LOCAL_CONFDIR_INDEX);
+ 			LUA_TABLE_TO_HASH(paths, RSPAMD_RUNDIR_INDEX);
+ 			LUA_TABLE_TO_HASH(paths, RSPAMD_DBDIR_INDEX);
+ 			LUA_TABLE_TO_HASH(paths, RSPAMD_LOGDIR_INDEX);

--- a/modules/default.nix
+++ b/modules/default.nix
@@ -17,6 +17,7 @@
     core/version.nix
     services/reverse-proxy
     services/TLS
+    services/email/rspamd.nix
     services/email/opendkim.nix
     services/email/postfix.nix
     services/email/pfix-srsd.nix

--- a/modules/services/email/dovecot/filter_bin/rspamd.sh
+++ b/modules/services/email/dovecot/filter_bin/rspamd.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+set -o errexit
+cat | rspamc --header="settings-id=delivery" -d "$1" -h /run/rspamd/worker-controller.sock -m

--- a/modules/services/email/dovecot/imap_sieve/report-ham.sieve
+++ b/modules/services/email/dovecot/imap_sieve/report-ham.sieve
@@ -1,0 +1,19 @@
+require ["vnd.dovecot.pipe", "copy", "imapsieve", "environment", "variables"];
+
+if environment :matches "imap.mailbox" "*" {
+  set "mailbox" "${1}";
+}
+
+if string "${mailbox}" "Trash" {
+  stop;
+}
+
+if environment :matches "imap.user" "*" {
+  set "username" "${1}";
+}
+
+if environment :matches "imap.email" "*" {
+  set "email" "${1}";
+}
+
+pipe :copy "learn-ham.sh" [ "${username}", "${email}" ];

--- a/modules/services/email/dovecot/imap_sieve/report-spam.sieve
+++ b/modules/services/email/dovecot/imap_sieve/report-spam.sieve
@@ -1,0 +1,11 @@
+require ["vnd.dovecot.pipe", "copy", "imapsieve", "environment", "variables"];
+
+if environment :matches "imap.user" "*" {
+  set "username" "${1}";
+}
+
+if environment :matches "imap.email" "*" {
+  set "email" "${1}";
+}
+
+pipe :copy "learn-spam.sh" [ "${username}", "${email}" ];

--- a/modules/services/email/dovecot/pipe_bin/learn-ham.sh
+++ b/modules/services/email/dovecot/pipe_bin/learn-ham.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+set -o errexit
+exec rspamc -c bayes_users -d "$2" -h /run/rspamd/worker-controller.sock learn_ham

--- a/modules/services/email/dovecot/pipe_bin/learn-spam.sh
+++ b/modules/services/email/dovecot/pipe_bin/learn-spam.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+set -o errexit
+exec rspamc -c bayes_users -d "$2" -h /run/rspamd/worker-controller.sock learn_spam

--- a/modules/services/email/dovecot/sieve/file-spam.sieve
+++ b/modules/services/email/dovecot/sieve/file-spam.sieve
@@ -1,0 +1,12 @@
+require ["fileinto", "reject", "envelope", "mailbox", "reject"];
+
+# spamassassin
+if header :contains "X-Spam-Flag" "YES" {
+  fileinto :create "Spam";
+  stop;
+}
+# rspamd
+if header :contains "X-Spam" "YES" {
+  fileinto :create "Spam";
+  stop;
+}

--- a/modules/services/email/dovecot/sieve/rspamd.sieve
+++ b/modules/services/email/dovecot/sieve/rspamd.sieve
@@ -1,0 +1,7 @@
+require ["vnd.dovecot.filter", "envelope", "variables"];
+
+if envelope :matches "to" "*" {
+  set "destination" "${1}";
+}
+
+filter "rspamd.sh" [ "${destination}" ];

--- a/modules/services/email/rspamd.nix
+++ b/modules/services/email/rspamd.nix
@@ -1,0 +1,24 @@
+# Replacement from master branch 24. Nov. 2018
+# This includes:
+#   https://github.com/NixOS/nixpkgs/pull/51012
+#   https://github.com/NixOS/nixpkgs/pull/49809
+#   https://github.com/NixOS/nixpkgs/pull/49792
+#   https://github.com/NixOS/nixpkgs/pull/49620
+# Can be removed after 19.03 release
+{pkgs, ...}:
+let
+  nixpkgs = builtins.fetchTarball {
+    url = https://github.com/NixOS/nixpkgs/archive/0d753af6617bb74535af0601a2cdce1a8c647889.tar.gz;
+    sha256 = "1jsvf4akcwifjmgyhnc5s7zl7wss93vpm23z5yxyzy7vnh9x429c";
+  };
+in {
+  disabledModules = [
+    "services/mail/rspamd.nix"
+    "services/mail/rspamd.nix:anon-1"
+    "services/mail/rspamd.nix:anon-2"
+    "services/mail/rspamd.nix:anon-3"
+  ];
+  imports = [
+    "${nixpkgs}/nixos/modules/services/mail/rspamd.nix"
+  ];
+}

--- a/modules/services/email/rspamd/groups.conf
+++ b/modules/services/email/rspamd/groups.conf
@@ -1,0 +1,23 @@
+group "bayes_user" {
+    symbol {
+        BAYES_SPAM_USER {
+            weight = 4.0;
+            description = "Message probably spam, probability: ";
+        }
+    }
+    symbol {
+        BAYES_HAM_USER {
+            weight = -3.0;
+            description = "Message probably ham, probability: ";
+        }
+    }
+}
+
+group "upstream" {
+  symbol {
+    UPSTREAM_SCORE = {
+      weight = 1.0;
+      description = "Loaded upstream score";
+    }
+  }
+}

--- a/modules/services/email/rspamd/milter_headers.conf
+++ b/modules/services/email/rspamd/milter_headers.conf
@@ -1,0 +1,2 @@
+skip_local = false;
+use = ["x-spamd-result", "x-spam-status"];

--- a/modules/services/email/rspamd/rspamd.local.lua
+++ b/modules/services/email/rspamd/rspamd.local.lua
@@ -1,0 +1,20 @@
+local rspamd_logger = require "rspamd_logger"
+
+rspamd_config.UPSTREAM_SCORE = {
+  callback = function(task)
+    local xss = task:get_header('X-Spam-Status')
+    if xss then
+      rspamd_logger.debugx(rspamd_config, 'Got upstream header %s', xss)
+      local score = string.gsub(xss, "^.*%sscore=(%-?%d+%.%d+)$", "%1")
+      rspamd_logger.debugx(rspamd_config, 'Got upstream score %s', score)
+      return tonumber(score)
+    else
+      rspamd_logger.debugx(rspamd_config, 'Found no upstream header')
+      return 0.0
+    end
+  end,
+  score = 1,
+  description = 'Score from milter scan',
+  group = "upstream",
+}
+rspamd_logger.debugx(rspamd_config, 'Work dammit!!!')

--- a/modules/services/email/rspamd/settings.conf
+++ b/modules/services/email/rspamd/settings.conf
@@ -1,0 +1,12 @@
+milter {
+  id = "milter";
+  apply {
+    groups_disabled = ["bayes_user", "upstream"];
+  }
+}
+delivery {
+	id = "delivery";
+	apply {
+		groups_enabled = ["bayes_user", "upstream"];
+	}
+}

--- a/modules/services/email/rspamd/statistic.conf
+++ b/modules/services/email/rspamd/statistic.conf
@@ -1,0 +1,103 @@
+classifier "bayes" {
+  tokenizer {
+    name = "osb";
+  }
+  cache {
+    path = "${DBDIR}/learn_cache.sqlite";
+  }
+  name = "bayes";
+  min_tokens = 11;
+  backend = "sqlite3";
+  languages_enabled = true;
+  min_learns = 200;
+
+  statfile {
+    symbol = "BAYES_HAM";
+    path = "${DBDIR}/bayes.ham.sqlite";
+    spam = false;
+  }
+  statfile {
+    symbol = "BAYES_SPAM";
+    path = "${DBDIR}/bayes.spam.sqlite";
+    spam = true;
+  }
+  learn_condition =<<EOD
+return function(task, is_spam, is_unlearn)
+  local prob = task:get_mempool():get_variable('bayes_prob', 'double')
+
+  if prob then
+    local in_class = false
+    local cl
+    if is_spam then
+      cl = 'spam'
+      in_class = prob >= 0.95
+    else
+      cl = 'ham'
+      in_class = prob <= 0.05
+    end
+
+    if in_class then
+      return false,string.format('already in class %s; probability %.2f%%',
+        cl, math.abs((prob - 0.5) * 200.0))
+    end
+  end
+
+  return true
+end
+EOD
+
+  .include(try=true; priority=1) "$LOCAL_CONFDIR/local.d/classifier-bayes.conf"
+  .include(try=true; priority=10) "$LOCAL_CONFDIR/override.d/classifier-bayes.conf"
+}
+classifier "bayes" {
+  tokenizer {
+    name = "osb";
+  }
+  cache {
+    path = "${DBDIR}/learn_cache.sqlite";
+  }
+  name = "bayes_users";
+  min_tokens = 11;
+  backend = "sqlite3";
+  users_enabled = true;
+  languages_enabled = true;
+  min_learns = 200;
+
+  statfile {
+    symbol = "BAYES_HAM_USER";
+    path = "${DBDIR}/bayes.ham.sqlite";
+    spam = false;
+  }
+  statfile {
+    symbol = "BAYES_SPAM_USER";
+    path = "${DBDIR}/bayes.spam.sqlite";
+    spam = true;
+  }
+  learn_condition =<<EOD
+return function(task, is_spam, is_unlearn)
+  local prob = task:get_mempool():get_variable('bayes_prob', 'double')
+
+  if prob then
+    local in_class = false
+    local cl
+    if is_spam then
+      cl = 'spam'
+      in_class = prob >= 0.95
+    else
+      cl = 'ham'
+      in_class = prob <= 0.05
+    end
+
+    if in_class then
+      return false,string.format('already in class %s; probability %.2f%%',
+        cl, math.abs((prob - 0.5) * 200.0))
+    end
+  end
+
+  return true
+end
+EOD
+
+  .include(try=true; priority=1) "$LOCAL_CONFDIR/local.d/classifier-bayes-user.conf"
+  .include(try=true; priority=10) "$LOCAL_CONFDIR/override.d/classifier-bayes-user.conf"
+}

--- a/modules/services/email/test/default.nix
+++ b/modules/services/email/test/default.nix
@@ -198,5 +198,10 @@ in {
     $mail1->waitForOpenPort(8993);
     $mail2->waitForOpenPort(8993);
     $mail1->succeed('curl -L https://mail.example.org/ | grep -qF "${rcSearchFor}"');
+    # Check spam learning
+    $mail2->waitUntilSucceeds("journalctl -u dovecot2 | grep learn-spam.sh >&2");
+    $mail2->succeed('journalctl -u rspamd | grep "csession; rspamd_controller_learn_fin_task: </run/rspamd/worker-controller.sock> learned message as spam" >&2');
+    $mail2->waitUntilSucceeds("journalctl -u dovecot2 | grep learn-ham.sh >&2");
+    $mail2->succeed('journalctl -u rspamd | grep "csession; rspamd_controller_learn_fin_task: </run/rspamd/worker-controller.sock> learned message as ham" >&2');
   '';
 }

--- a/modules/services/email/test/test.py
+++ b/modules/services/email/test/test.py
@@ -40,58 +40,80 @@ class EmailTest(unittest.TestCase):
             smtp.login(from_addr, from_attrs['plainPasswd'])
             smtp.sendmail(from_addr, [to_addr], msg.as_string())
 
-    def wait_for_new_emails(self, user=None):
+    def wait_for_new_emails(self, user=None, folder='INBOX', search='(UNSEEN)'):
         newmails = []
         while len(newmails) == 0:
             for name, attrs in self.accounts.items():
                 if user is not None and name != user:
                     continue
                 try:
-                    attrs['imap'].select()
+                    attrs['imap'].select(folder)
                 except imaplib.IMAP4.error:
                     continue
-                response = attrs['imap'].search(None, '(UNSEEN)')[1]
+                response = attrs['imap'].search(None, search)[1]
                 unread_msg_ids = response[0].split()
                 for msgid in unread_msg_ids:
                     result = attrs['imap'].fetch(msgid, '(UID BODY[TEXT])')[1]
-                    newmails.append(result[0][1].strip().decode())
+                    newmails.append((msgid.strip().decode(), result[0][1].strip().decode()))
                 attrs['imap'].close()
         return newmails
 
-    def wait_for_one_email(self, user=None):
-        newmails = self.wait_for_new_emails(user)
+    def wait_for_one_email(self, user=None, folder='INBOX', search='(UNSEEN)'):
+        newmails = self.wait_for_new_emails(user, folder, search)
         self.assertEqual(len(newmails), 1)
         return newmails[0]
+
+    def mark_as_spam(self, user, msg_ids):
+        for name, attrs in self.accounts.items():
+            if name != user:
+                continue
+            attrs['imap'].select()
+            attrs['imap'].copy(','.join(msg_ids), 'Spam')
+            for num in msg_ids:
+              attrs['imap'].store(num, '+FLAGS', '\\Deleted')
+            attrs['imap'].expunge()
+            attrs['imap'].close()
+
+    def mark_as_ham(self, user, msg_ids):
+        for name, attrs in self.accounts.items():
+            if name != user:
+                continue
+            attrs['imap'].select('Spam')
+            attrs['imap'].copy(','.join(msg_ids), 'INBOX')
+            for num in msg_ids:
+              attrs['imap'].store(num, '+FLAGS', '\\Deleted')
+            attrs['imap'].expunge()
+            attrs['imap'].close()
 
     def test_send_to_same_server(self):
         print ("test_send_to_same_server ~~~~")
         self.send_email('alice', 'bob', 'Hello Bob from Alice!')
-        text = self.wait_for_one_email('bob')
+        (_, text) = self.wait_for_one_email('bob')
         self.assertEqual(text, 'Hello Bob from Alice!')
 
     def test_send_to_different_server(self):
         print ("test_send_to_different_server ~~~~")
         self.send_email('foo', 'bob', 'Hello Bob from Foo!')
-        text = self.wait_for_one_email('bob')
+        (_, text) = self.wait_for_one_email('bob')
         self.assertEqual(text, 'Hello Bob from Foo!')
 
     def test_send_to_catchall(self):
         print ("test_send_to_catchall ~~~~")
         self.send_email('bar', 'spameater', 'Eat this!',
                         to_addr='spam@catchall.example')
-        text = self.wait_for_one_email('spameater')
+        (_, text) = self.wait_for_one_email('spameater')
         self.assertEqual(text, 'Eat this!')
 
     def test_check_quota(self):
         print ("test_check_quota ~~~~")
         msg = ("Hello, how's your quota? " * 10).strip()
         self.send_email('alice', 'bar', msg)
-        text = self.wait_for_one_email('bar')
+        (_, text) = self.wait_for_one_email('bar')
         self.assertEqual(text, msg)
 
         msg = ("Where is your quota? " * 1000).strip()
         self.send_email('bob', 'bar', msg)
-        text = self.wait_for_one_email('bob')
+        (_, text) = self.wait_for_one_email('bob')
         self.assertRegex(text, RE_DSN_FAILED)
 
     def test_aliases(self):
@@ -99,14 +121,14 @@ class EmailTest(unittest.TestCase):
         msg = 'Hi different Alice!'
         self.send_email('spameater', 'alice', msg,
                         to_addr='anotheralice@example.net')
-        text = self.wait_for_one_email('alice')
+        (_, text) = self.wait_for_one_email('alice')
         self.assertEqual(text, msg)
 
     def test_softbounce_nonexisting_address(self):
         print ("test_softbounce_nonexisting_address ~~~~")
         msg = 'Is there anyone?'
         self.send_email('alice', None, msg, to_addr='xxx@example.com')
-        text = self.wait_for_one_email('alice')
+        (_, text) = self.wait_for_one_email('alice')
         self.assertRegex(text, RE_DSN_FAILED)
         self.assertIn("This is the mail system at host mx.example.com",
                       text)
@@ -121,6 +143,25 @@ class EmailTest(unittest.TestCase):
         self.assertEqual(554, err.smtp_code)
         self.assertEqual(b'5.7.1 Gtube pattern', err.smtp_error)
 
+    def test_spam_filter_add_header(self):
+        print ("test_spam_filter_add_header ~~~~")
+        msg = 'YJS*C4JDBQADN1.NSBN3*2IDNEN*GTUBE-STANDARD-ANTI-UBE-TEST-EMAIL*C.34X'
+        self.send_email('spameater', 'alice', msg,
+                        to_addr='anotheralice@example.net')
+        (_, text) = self.wait_for_one_email('alice', 'Spam')
+        self.assertEqual(text, msg)
+
+    def test_spam_filter_train(self):
+        print ("test_spam_filter_train ~~~~")
+        msg = 'This is a message to train the stats filter and see how it works.'
+        self.send_email('spameater', 'foo', msg,
+                        to_addr='foo@example.com')
+        (msgid, text) = self.wait_for_one_email('foo')
+        self.assertEqual(text, msg)
+        self.mark_as_spam('foo', [msgid])
+        (msgid, text) = self.wait_for_one_email('foo', 'Spam', 'ALL')
+        self.assertEqual(text, msg)
+        self.mark_as_ham('foo', [msgid])
 
 if __name__ == '__main__':
     unittest.main(verbosity=2)


### PR DESCRIPTION
This commit adds per-user bayesian spam filtering and training to the
email module. It does this by making spam filtering a two part process
where the first is run as part of a postfix milter and the second is
run by dovecot as part of a sieve script that is run before any other
sieve scripts. And by training the bayesian filter using the Dovecot
IMAPSieve Plugin so that moving a mail to the Spam folder trains that
mail as spam and moving a mail from Spam folder to any other folder
trains as ham.

This commit also adds an assertion that Rspamd version is at least
1.7.3 since older versions did not support the settings option in the
proxy worker which is used to exclude the rules checked as part of final
delivery from the milter run.

To support the custom rule that loads the spam score from the first run
into the second run I needed Rspamd to support storing the custom Lua
rules in LOCAL_CONFDIR. This change was not added to Rspamd until after
version 1.8.0 and so to support the older versions of Rspamd found in
NixOS 18.09 and NixOS Unstable I have back-ported the change to versions
1.7.3, 1.7.9 and 1.8.0 of Rspamd which are versions I have come across
in NixOS.

The latest version of the Rspamd module in NixOS Unstable include
several changes, made by me, that made it possible to implement this
feature and so to also support NixOS 18.09 this commit also includes a
replacement module for Rspamd that disables the Rspamd module in nixpkgs
and instead downloads and uses a newer one from NixOS Unstable.

One last thing I did that I am not 100% about what other peoples opinions are is that I changed the script that moves mails to the Spam folder so that it runs after user defined scripts instead of before since I wanted to allow users to override if they wanted custom spam handling.