### PR TITLE
Roundcube Webservice

### DIFF
--- a/modules/services/email/nixcloud-email.nix
+++ b/modules/services/email/nixcloud-email.nix
@@ -32,7 +32,7 @@ let
     };
   };
   # unique set of primary FQDN and additional domains in nixcloud.email, prefixed with `mail.` depending on `autoMailDomain`
-  rcWebMailFQDNs = map (fqdn: (lib.optionalString (cfg.webmail.autoMailDomain) "mail.") + fqdn) (lib.unique([ cfg.fqdn ] ++ cfg.domains));
+  rcWebMailFQDNs = map (fqdn: (lib.optionalString (cfg.webmail.autoMailDomain && ((builtins.match "^mail\..+" fqdn) == null)) "mail.") + fqdn) (lib.unique([ cfg.fqdn ] ++ cfg.domains));
 
 in {
   imports = [

--- a/modules/services/email/nixcloud-email.nix
+++ b/modules/services/email/nixcloud-email.nix
@@ -157,6 +157,23 @@ in {
         Whether to enforce the Sender Policy Framework.
       '';
     };
+    webmail = {
+      enable = mkOption {
+        type = types.bool;
+        default = true;
+        description = ''
+          Provide a webmail interface for `nixcloud.email`-enabled domains
+        '';
+      };
+      autoMailDomain = mkOption {
+        type = types.bool;
+        default = true;
+        description = ''
+          Assumes webmail should be made available under `mail.<domain>`.
+          Uses `domain` as defined if set to `false`.
+        '';
+      };
+    };
     users = mkOption {
       type = types.listOf (types.submodule {
         imports = [ ./virtual-mail-submodule.nix ];

--- a/modules/services/email/nixcloud-email.nix
+++ b/modules/services/email/nixcloud-email.nix
@@ -363,6 +363,9 @@ in {
           587  # dovecot (submission)
           993  # imaps (dovecot)
           4190 # sieve
+        ] ++ lib.optionals cfg.webmail.enable [
+          80  # HTTP
+          443 # HTTPS
         ];
       };
 

--- a/modules/services/email/nixcloud-email.nix
+++ b/modules/services/email/nixcloud-email.nix
@@ -23,6 +23,17 @@ let
       }
   '';
 
+  # generate attrSet for a single webmail webservice
+  mkWebMailWebService = fqdn: {
+    enable = true;
+    proxyOptions = {
+      domain = "${fqdn}";
+      port = 8993;
+    };
+  };
+  # unique set of primary FQDN and additional domains in nixcloud.email, prefixed with `mail.` depending on `autoMailDomain`
+  rcWebMailFQDNs = map (fqdn: (lib.optionalString (cfg.webmail.autoMailDomain) "mail.") + fqdn) (lib.unique([ cfg.fqdn ] ++ cfg.domains));
+
 in {
   imports = [
     (import ./virtual-mail-users.nix ({virtualMailDir = cfg.virtualMailDir;} // args))

--- a/modules/services/email/nixcloud-email.nix
+++ b/modules/services/email/nixcloud-email.nix
@@ -281,6 +281,10 @@ in {
       };
     })
 
+    (lib.mkIf cfg.webmail.enable {
+      nixcloud.webservices.roundcube = lib.fold (el: c: c // {"${el}" = mkWebMailWebService el;}) {} (rcWebMailFQDNs);
+    })
+
     (lib.mkIf cfg.enableDKIM {
       users.users.postfix.extraGroups = [ "opendkim" ];
       services.opendkim = {

--- a/modules/services/email/nixcloud-email.nix
+++ b/modules/services/email/nixcloud-email.nix
@@ -24,11 +24,12 @@ let
   '';
 
   # generate attrSet for a single webmail webservice
-  mkWebMailWebService = fqdn: port: {
+  mkWebMailWebService = primaryFQDN: extraFQDN: port: {
     enable = true;
     proxyOptions = {
-      domain = "${fqdn}";
+      domain = "${extraFQDN}";
       port = port;
+      TLS = "${primaryFQDN}";
     };
   };
   # unique set of primary FQDN and additional domains in nixcloud.email, prefixed with `mail.` depending on `autoMailDomain`
@@ -267,7 +268,7 @@ in {
 
       nixcloud.TLS.certs."${cfg.fqdn}" = {
         domain = "${cfg.fqdn}";
-        extraDomains = map (x: "mail.${x}") cfg.domains;
+        extraDomains = lib.unique((map (x: "mail.${x}") cfg.domains) ++ rcWebMailFQDNs);
         reload = [ "postfix.service" "dovecot2.service" ];
       };
 
@@ -286,7 +287,7 @@ in {
 	# makes portMap contain an attrSet where the key is the FQDN and the value a port for the
 	# corresponding webservice, e.g. `{ "domain.a" = 8993; "domain.b" = 8994; "domain.c" = 8995; }`
 	portMap = lib.listToAttrs (lib.imap0 (i: v: {name = v; value = 8993+i;}) rcWebMailFQDNs);
-      in lib.fold (el: c: c // {"${el}" = mkWebMailWebService el portMap."${el}";}) {} (rcWebMailFQDNs);
+      in lib.fold (el: c: c // {"${el}" = mkWebMailWebService cfg.fqdn el portMap."${el}";}) {} (rcWebMailFQDNs);
     })
 
     (lib.mkIf cfg.enableDKIM {

--- a/modules/web/default.nix
+++ b/modules/web/default.nix
@@ -17,6 +17,7 @@
     static-darkhttpd  = services/static-darkhttpd;
     static-nginx      = services/static-nginx;
     mattermost        = services/mattermost;
+    roundcube         = services/roundcube;
   }) ++ lib.singleton customModule;
 
   config = let

--- a/modules/web/services/roundcube/default.nix
+++ b/modules/web/services/roundcube/default.nix
@@ -7,11 +7,47 @@ let
     $config = array(
       'db_dsnw' => 'sqlite:///${config.stateDir}/roundcube/sqlite.db?mode=0600',
       'log_dir' => '${config.stateDir}/log',
+      'enable_spellcheck' => ${if config.config.enable_spellcheck then "True" else "False"},
     );
+    ${config.extraConfig}
   '';
 in
 {
-  options = {};
+  options = {
+    config = {
+      enable_spellcheck = mkOption {
+        type = types.bool;
+        default = false;
+        description = ''
+          Enable spellchecking when composing mails
+          WARNING: Due to possible privacy implications when using an online spellchecking
+          service this function is disabled by default.
+        '';
+      };
+      spellcheck_engine = mkOption {
+        type = types.nullOr (types.enum ["googie" "pspell" "enchant" "atd"]);
+        default = null;
+        description = ''
+          The spellcheck engine to be used.
+          WARNING: Some engines might use online services, which has privacy implications.
+        '';
+      };
+    };
+    extraConfig = mkOption {
+      type = types.lines;
+      default = "";
+      example = ''
+        $config['log_date_format'] = 'd-M-Y H:i:s O';
+        $config['imap_timeout']    = 30;
+      '';
+      description = ''
+        Any additional lines to be appended to Roundcube's
+        configuration file.
+        See the reference documentation:
+        <link xlink:href='https://github.com/roundcube/roundcubemail/wiki/Configuration'/>.
+      '';
+    };
+  };
 
   config = let
     version = "1.3.8";

--- a/modules/web/services/roundcube/default.nix
+++ b/modules/web/services/roundcube/default.nix
@@ -1,0 +1,62 @@
+{ config, lib, pkgs, apache, mkUniqueUser, mkUniqueGroup, ... }:
+
+with lib;
+let
+  roundcubeConfigFile = pkgs.writeText "config.inc.php" ''
+    <?php
+    $config = array(
+      'db_dsnw' => 'sqlite:///${config.stateDir}/roundcube/sqlite.db?mode=0600',
+      'log_dir' => '${config.stateDir}/log',
+    );
+  '';
+in
+{
+  options = {};
+
+  config = let
+    version = "1.3.8";
+    roundcubeRoot = pkgs.stdenv.mkDerivation rec {
+      name= "roundcube-${version}";
+
+      src = pkgs.fetchurl {
+        url = "https://github.com/roundcube/roundcubemail/releases/download/${version}/roundcubemail-${version}-complete.tar.gz";
+        sha256 = "018djad7ygfl9c9f2l2j42qkg31ml3hs2f01f0dk361zckwk77n4";
+      };
+
+      buildPhase = ''
+        rm -rf installer
+      '';
+      installPhase = ''
+        mkdir -p $out
+        cp -r . $out
+        ln -sf ${roundcubeConfigFile} $out/config/config.inc.php
+      '';
+    };
+  in {
+    webserver.variant = "apache";
+    webserver.systemPackages = [pkgs.php];
+    webserver.init = ''
+      mkdir -p ${config.stateDir}/roundcube/log
+      chown -R ${mkUniqueUser config.webserver.user}:${mkUniqueGroup config.webserver.group} ${config.stateDir}/roundcube
+      chmod -R 750 ${config.stateDir}/roundcube
+    '';
+    webserver.apache.enablePHP = true;
+    webserver.apache.extraConfig = ''
+      <Directory "${roundcubeRoot}">
+        Require all granted
+      </Directory>
+      <Directory "${roundcubeRoot}/config">
+        Require all denied
+      </Directory>
+      DocumentRoot ${roundcubeRoot}
+      DirectoryIndex index.php
+    '';
+  };
+
+  meta = {
+    description = "Open Source Webmail Software";
+    maintainers = with maintainers; [ eliasp ];
+    license = licenses.gpl3;
+    platforms = platforms.all;
+  };
+}


### PR DESCRIPTION
This is a WIP implementation of the [Roundcube](https://github.com/roundcube/roundcubemail) Webservice to provide Roundcube either as configurable standalone webservice or implicitely configured webmail for `nixcloud.email`.

All the configurability is still TBD - this represents only the plain webservice so far.

The current state allows to login successfully:
![image](https://user-images.githubusercontent.com/48491/50741891-2287b900-1204-11e9-8445-3c2db95f4fd7.png)

Currently using this configuration for tests:
```Nix
{
  # […]
  nixcloud.tests.enable = false; # only temporarily :)
  nixcloud.email = {
    enable = true;
    ipAddress = "127.0.0.1";
    ip6Address = "::1";
    domains = [ "roundcube.test" "secondary.test" ];
    fqdn = "roundcube.test";
    webmail.enable = true;
    users = [
      {
        name = "rc";
        domain = "roundcube.test";
        password = "$5$Kg2B11kukpC4$DPULLSNCFm9af1Obb1g/h/gLMx4jR4r/ZnuwEHNn4U7"; # test123
      }
      {
        name = "sec";
        domain = "secondary.test";
        password = "$5$Kg2B11kukpC4$DPULLSNCFm9af1Obb1g/h/gLMx4jR4r/ZnuwEHNn4U7"; # test123
      }
    ];
  };
}
```