### PR TITLE
doc: mailserver add information about firewall

### DIFF
--- a/documentation/nixcloud.email.md
+++ b/documentation/nixcloud.email.md
@@ -75,6 +75,14 @@ Thanks to the support of https://nlnet.nl!
           { name = "foo1"; domain = "dune2.de"; password = "{PLAIN}asdfasdfasdfasdf"; }
         ];
       };
+      
+    # If using the firewall
+    # networking.firewall.allowedTCPPorts = [ 
+    #   25 # enable smtp for other servers
+    #   143 # Enable using imap
+    #   587 # Enable smtp for users
+    # ]
+  ];
 
 ## DNS entries
 


### PR DESCRIPTION
List the ports that should be opened in the firewall for the email server to work.

As a newbie to email server I had to look them up as port 25 is not mentionned anywhere in the documentation.

And BTW, awesome project it only took me a couple of hours to setup everything, the DNS part could be improved but i'm not sure I've understood everything I did.