### PR TITLE
nginx_check_config.nix, nixcloud.TLS: use 4 letter password

### DIFF
--- a/modules/services/TLS/default.nix
+++ b/modules/services/TLS/default.nix
@@ -17,9 +17,9 @@ let
     # Create self-signed key
     workdir=/tmp
     echo "Create a self signed CA 1/2"
-    ${pkgs.openssl.bin}/bin/openssl genrsa -des3 -passout pass:x -out $workdir/server.pass.key 2048
+    ${pkgs.openssl.bin}/bin/openssl genrsa -des3 -passout pass:xxxx -out $workdir/server.pass.key 2048
     echo "Create a self signed CA 2/2"
-    ${pkgs.openssl.bin}/bin/openssl rsa -passin pass:x -in $workdir/server.pass.key -out $workdir/server.key
+    ${pkgs.openssl.bin}/bin/openssl rsa -passin pass:xxxx -in $workdir/server.pass.key -out $workdir/server.key
     echo "Create a CSR"
     ${pkgs.openssl.bin}/bin/openssl req -new -key $workdir/server.key -out $workdir/server.csr -subj "/C=DE/ST=Burrow/L=Linux/O=OrgName/OU=nixcloud IT Department"
 

--- a/modules/web/webserver/lib/nginx_check_config.nix
+++ b/modules/web/webserver/lib/nginx_check_config.nix
@@ -31,8 +31,8 @@ in rec {
       # so this smart code, borrowed from fpletz, will create one
       echo "------------ generating fake certificates for nginx syntax check ---------------"
       workdir=./
-      ${pkgs.openssl.bin}/bin/openssl genrsa -des3 -passout pass:x -out $workdir/server.pass.key 2048
-      ${pkgs.openssl.bin}/bin/openssl rsa -passin pass:x -in $workdir/server.pass.key -out $workdir/server.key
+      ${pkgs.openssl.bin}/bin/openssl genrsa -des3 -passout pass:xxxx -out $workdir/server.pass.key 2048
+      ${pkgs.openssl.bin}/bin/openssl rsa -passin pass:xxxx -in $workdir/server.pass.key -out $workdir/server.key
       ${pkgs.openssl.bin}/bin/openssl req -new -key $workdir/server.key -out $workdir/server.csr \
         -subj "/C=UK/ST=Warwickshire/L=Leamington/O=OrgName/OU=IT Department/CN=example.com"
       ${pkgs.openssl.bin}/bin/openssl x509 -req -days 1 -in $workdir/server.csr -signkey $workdir/server.key -out $workdir/server.crt


### PR DESCRIPTION
OpenSSL 1.1.1c (which is currently in nixos-unstable) fails when generating a key with a single letter password:

```
$ openssl genrsa -des3 -passout pass:x -out server.pass.key 2048
Generating RSA private key, 2048 bit long modulus (2 primes)
....................+++++
.............................+++++
e is 65537 (0x010001)
140283268834304:error:28078065:UI routines:UI_set_result_ex:result too small:crypto/ui/ui_lib.c:903:You must type in 4
to 1023 characters
140283268834304:error:28078065:UI routines:UI_set_result_ex:result too small:crypto/ui/ui_lib.c:903:You must type in 4
to 1023 characters
140283268834304:error:0906906F:PEM routines:PEM_ASN1_write_bio:read key:crypto/pem/pem_lib.c:357:
```

Compare this behaviour to OpenSSL 1.0.2r (current nixos-19.03) where a one letter password suffices. That means we need to use a longer password.

Personally I'm only affected by the occurence in `modules/web/webserver/lib/nginx_check_config.nix` but I guess its safe to also fix `modules/services/TLS/default.nix`.