### PR TITLE
Fix letsencrypt tests, user type definition and getSubmodules function

### DIFF
--- a/modules/services/TLS/test.nix
+++ b/modules/services/TLS/test.nix
@@ -3,13 +3,13 @@
 with pkgs.lib;
 
 let
-  commonConfig = <nixpkgs/nixos/tests/common/letsencrypt/common.nix>;
-  snakeoil-certs = import (<nixpkgs/nixos/tests/common/letsencrypt/snakeoil-certs.nix>);
+  commonConfig = <nixpkgs/nixos/tests/common/acme/client>;
+  snakeoil-certs = import (<nixpkgs/nixos/tests/common/acme/server/snakeoil-certs.nix>);
 in rec {
   name = "nixcloud.TLS";
 
   nodes = rec {
-    letsencrypt =  <nixpkgs/nixos/tests/common/letsencrypt>;
+    acme =  <nixpkgs/nixos/tests/common/acme/server>;
 
     webserver = { config, pkgs, nodes, ... }: {
       imports = [ commonConfig ];
@@ -258,12 +258,12 @@ in rec {
   };
 
   testScript = ''
-    $letsencrypt->waitForUnit("default.target");
+    $acme->waitForUnit("default.target");
     $webserver->waitForUnit("default.target");
     $client->waitForUnit("default.target");
 
 
-    $letsencrypt->waitForUnit("multi-user.target");
+    $acme->waitForUnit("multi-user.target");
 
     # if the nixcloud.reverse-proxy doesn't make it, we don't need to go on
     $webserver->waitForUnit("nixcloud.reverse-proxy.service");

--- a/modules/services/reverse-proxy/test.nix
+++ b/modules/services/reverse-proxy/test.nix
@@ -227,10 +227,11 @@ in
     
     services.httpd = {
       enable = true;
-      listen = [{
-        port = 60000;
-        ip = "*";
-      }];
+      virtualHosts = {
+        "example.com" = {
+          listen = [{port = 60000; ip = "*";}];
+        };
+      };
       adminAddr="example@example.com";
     };
 

--- a/modules/web/core/base.nix
+++ b/modules/web/core/base.nix
@@ -15,9 +15,7 @@ let
     optionNames = lib.attrNames (lib.filterAttrs (lib.const isUnit) reEval);
   in lib.genAttrs optionNames (name: toplevel.options.systemd.${name});
 
-  getSubModules = opt: let
-    subModules = opt.type.getSubModules;
-  in map (m: m.submodule) subModules;
+  getSubModules = opt: opt.type.functor.wrapped.functor.payload.modules;
 
   availableInstanceDependencies = [
     "after" "before" "bindsTo" "conflicts" "partOf" "requiredBy" "requires"


### PR DESCRIPTION
This PR fixes #64.

I just  tried to pretty much implement what @Infinisil proposed in the issue as nix is still quite a bit of magic to me...

This PR only works for 20.03, NOT for 19.09 (the submodule magic from infinisil doesn't work without his change in nixpkgs..) and on unstable the test suite can't run through. Infinisil recommended to make it backwards compatible but I really don't know how to do this.
My approach would be to simply create different branches for the different channels as it seems like there are quite some things that have changed... Or create a `19.09` Tag on the last commit that works on that channel...

I tried to fix the tests and it *seems* to me like they run successful on the 20.03 channel. I also use this commit on a personal mailserver without issues until now. On unstable the test suite seems to log this in an endless loop:
```
machine: running command: nc -z localhost 80
machine: exit status 1
(0.01 seconds)
```
after this:
```
machine# [   53.880305] systemd[1]: static-nginx-foo-nginx.service: Scheduled restart job, restart counter is at 4.
machine# [   53.909956] systemd[1]: static-nginx-bar-nginx.service: Scheduled restart job, restart counter is at 4.
machine# [   53.928762] systemd[1]: nixcloud.reverse-proxy.service: Scheduled restart job, restart counter is at 4.
machine# [   53.942133] systemd[1]: Stopped Connects several webservers together and manages TLS and makes hosting easy!.
machine# [   53.957899] systemd[1]: Starting Connects several webservers together and manages TLS and makes hosting easy!...
machine# [   53.963556] nginx[1070]: nginx: [alert] could not open error log file: open() "/var/log/nginx/error.log" failed (2: No such file or directory)
machine# [   53.970189] nginx[1070]: 2020/08/08 18:29:46 [warn] 1070#1070: the "user" directive makes sense only if the master process runs with super-user privileges, ignored in /nix/store/048z89pv9swzl0zxf6wb5xry3a08lmgj-nginx_check_config/static-nginx-bar.conf:1
machine# [   53.975840] nginx[1070]: 2020/08/08 18:29:46 [emerg] 1070#1070: mkdir() "/var/cache/nginx/client_body" failed (2: No such file or directory)
machine# [   53.981025] systemd[1]: Stopped Nginx HTTPD.
machine# [   53.984588] nginx[1071]: nginx: [alert] could not open error log file: open() "/var/log/nginx/error.log" failed (2: No such file or directory)
machine# [   53.989739] nginx[1071]: 2020/08/08 18:29:46 [warn] 1071#1071: the "user" directive makes sense only if the master process runs with super-user privileges, ignored in /nix/store/k3nrmia48dxp1flpvn6a1nn126lpsn7r-nginx_check_config/static-nginx-foo.conf:1
machine# [   53.995229] nginx[1071]: 2020/08/08 18:29:46 [emerg] 1071#1071: mkdir() "/var/cache/nginx/client_body" failed (2: No such file or directory)
machine# [   54.004386] systemd[1]: Started Nginx HTTPD.
machine# [   54.009533] systemd[1]: Stopped Nginx HTTPD.
machine# [   54.013562] systemd[1]: Started Nginx HTTPD.
machine# [   54.017165] systemd[1]: static-nginx-foo-nginx.service: Main process exited, code=exited, status=1/FAILURE
machine# [   54.020886] systemd[1]: static-nginx-foo-nginx.service: Failed with result 'exit-code'.
machine# [   54.024272] systemd[1]: static-nginx-bar-nginx.service: Main process exited, code=exited, status=1/FAILURE
machine# [   54.033648] systemd[1]: static-nginx-bar-nginx.service: Failed with result 'exit-code'.
machine# [   54.037432] nginx[1080]: nginx: [alert] could not open error log file: open() "/var/log/nginx/error.log" failed (2: No such file or directory)
machine# [   54.041009] nginx[1080]: 2020/08/08 18:29:46 [emerg] 1080#1080: mkdir() "/var/cache/nginx/client_body" failed (2: No such file or directory)
machine# [   54.047841] systemd[1]: Started Connects several webservers together and manages TLS and makes hosting easy!.
machine# [   54.051264] systemd[1]: nixcloud.reverse-proxy.service: Main process exited, code=exited, status=1/FAILURE
machine# [   54.054008] systemd[1]: nixcloud.reverse-proxy.service: Failed with result 'exit-code'.
machine: running command: nc -z localhost 80
machine: exit status 1
(0.01 seconds)
machine: running command: nc -z localhost 80
machine: exit status 1
(0.01 seconds)
```

I don't know what the problem is there, the tests are still a bit too much magic for me to understand. If you could help me with that and also run the tests on 20.03 I would be really glad.

I'd like to get rid of all the deprecation warnings (e.g. perl tests instead of python tests or users as list instead of set) so that the bump to 20.09 will work later on. But before that the tests should at least run successfully on unstable...