### PR TITLE
20.09: Use attrsOf instead of loaOf

### DIFF
--- a/modules/services/email/opendkim.nix
+++ b/modules/services/email/opendkim.nix
@@ -88,16 +88,14 @@ in {
 
   config = mkIf cfg.enable {
 
-    users.extraUsers = optionalAttrs (cfg.user == "opendkim") (singleton
-      { name = "opendkim";
-        group = cfg.group;
+    users.extraUsers = optionalAttrs (cfg.user == "opendkim") { opendkim =
+      { group = cfg.group;
         uid = config.ids.uids.opendkim;
-      });
+      };};
 
-    users.extraGroups = optionalAttrs (cfg.group == "opendkim") (singleton
-      { name = "opendkim";
-        gid = config.ids.gids.opendkim;
-      });
+    users.extraGroups = optionalAttrs (cfg.group == "opendkim") { opendkim =
+      { gid = config.ids.gids.opendkim;
+      };};
 
     environment.systemPackages = [ pkgs.opendkim ];
 

--- a/modules/services/email/postfix.nix
+++ b/modules/services/email/postfix.nix
@@ -666,10 +666,7 @@ in
     {
 
       environment = {
-        etc = singleton
-          { source = "/var/lib/postfix/conf";
-            target = "postfix";
-          };
+        etc = { postfix.source = "/var/lib/postfix/conf"; };
 
         # This makes comfortable for root to run 'postqueue' for example.
         systemPackages = [ pkgs.postfix ];
@@ -685,22 +682,17 @@ in
         setgid = true;
       };
 
-      users.extraUsers = optional (user == "postfix")
-        { name = "postfix";
-          description = "Postfix mail server user";
+      users.extraUsers = optionalAttrs (user == "postfix") { postfix =
+        { description = "Postfix mail server user";
           uid = config.ids.uids.postfix;
           group = group;
-        };
+        };};
 
       users.extraGroups =
-        optional (group == "postfix")
-        { name = group;
-          gid = config.ids.gids.postfix;
-        }
-        ++ optional (setgidGroup == "postdrop")
-        { name = setgidGroup;
-          gid = config.ids.gids.postdrop;
-        };
+        optionalAttrs (group == "postfix")
+        { "${group}".gid = config.ids.gids.postfix; }
+        // optionalAttrs (setgidGroup == "postdrop")
+        { "${setgidGroup}".gid = config.ids.gids.postdrop; };
 
       systemd.services.postfix =
         { description = "Postfix mail server";

--- a/modules/services/reverse-proxy/default.nix
+++ b/modules/services/reverse-proxy/default.nix
@@ -393,14 +393,9 @@ in
     };
 
 
-    users.extraUsers = (singleton
-      { name = "${user}";
-        group = "${group}";
-      });
+    users.extraUsers."${user}".group = "${group}";
 
-    users.extraGroups = (singleton
-      { name = "${user}";
-      });
+    users.extraGroups."${user}" = {};
 
     nixcloud.tests.wanted = [ ./test.nix ];
   };


### PR DESCRIPTION
loaOf was deprecated in 20.03 and breaks in 20.09. See NixOS/nixpkgs#63103

Closes #70